### PR TITLE
Fix wrong link to Vagrant installation page

### DIFF
--- a/tools/vagrant.md
+++ b/tools/vagrant.md
@@ -45,4 +45,4 @@ To help you manage the development server via your browser, we've included these
 * [PhpMyAdmin](http://www.phpmyadmin.net/)
 * [Mailcatcher](http://mailcatcher.me/)
 
-To get started, head over to the [installation page](vagrant/1-installation.html).
+To get started, head over to the [installation page](vagrant/getting-started.html#installation).


### PR DESCRIPTION
There was a wrong link at the bottom of the page. 
Instead of pointing to missing installation page, now it's pointing to getting started guide. 